### PR TITLE
Correcting title and standardising DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -16,6 +16,20 @@
             "value": "fMRI"
         }
     ],
+    "distributions": [
+	        {
+			"formats": [
+				"NIfTI"
+            		],
+			"size" : 5.06,
+		        "unit" : {
+            			"value": "GB"
+		        },
+			"access": {
+				"landingPage": "https://www.openpain.org/"
+			}
+		}
+	],
     "version": "1.0",
     "privacy": "Open Access",
     "isAbout": [
@@ -32,7 +46,31 @@
                     "value": "152"
                 }
             ]
-        }
+        },
+	{
+			"category": "contact",
+			"values": [
+				{
+					"value": "A. Vania Apkarian, Director Center for Translational Pain Research, Northwestern University, Feinberg School of Medicine, a-apkarian@northwestern.edu"
+				}
+			]
+		},
+		{
+			"category": "files",
+			"values": [
+				{
+					"value": "492"
+				}
+			]
+		},
+		{
+			"category": "logo",
+			"values": [
+				{
+					"value": "http://openpain.org/images/OP_Pic1.jpg"
+				}
+			]
+		}
     ]
 }
 

--- a/DATS.json
+++ b/DATS.json
@@ -1,5 +1,5 @@
 {
-    "title": "OpenPain thermal",
+    "title": "OpenPain placebo_predict_tetreault",
     "description": "In this dataset you will find the following T1 and resting state scans for: * 20 Healthy controls. * 17 Osteoarthritis (OA) patients from a 2-week placebo only treatment (study 1) scanned before treatment. * 39 OA patients from a 3-month placebo vs duloxetine treatment (study 2) scanned before treatment. Demographics with age, gender, stratification, etc. can be found in the participants.tsv file. This data has been released to the public domain under the open data commons license, a copy of which is included. An additional copy has also been submitted to http://openfmri.org",
     
     "creators": [


### PR DESCRIPTION
This replaces the previous closed PR #1. In addition to adding the standardised fields under distribution and extraProperties as documented in CONP-PCNO/conp-dataset#125, the title field was changed from "openpain-thermal" to reflect the name of the repository.